### PR TITLE
Empty synchronizer app under 'experimental' target

### DIFF
--- a/build/config/phone/apps-experimental.list
+++ b/build/config/phone/apps-experimental.list
@@ -1,0 +1,3 @@
+apps/*
+outoftree_apps/*
+dev_apps/synchronizer

--- a/dev_apps/synchronizer/index.html
+++ b/dev_apps/synchronizer/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Coming soon</title>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <h1>Coming soon</h1>
+    <p>The synchronizer app is <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1195647">not yet implemented</a>, and is ignored by the build system unless you set the ENABLE_DATA_SYNC flag at build time, for instance in local.mk.</p>
+  </body>
+</html>

--- a/dev_apps/synchronizer/manifest.webapp
+++ b/dev_apps/synchronizer/manifest.webapp
@@ -1,0 +1,6 @@
+{
+  "name": "Synchronizer",
+  "description": "Syncs data with Firefox Sync",
+  "type": "certified",
+  "launch_path": "/index.html"
+}


### PR DESCRIPTION
@ferjm What do you think of adding an 'experimental' build target to add our app to?

Other options would include:
- pre-processing the apps-target.list files, as you proposed
- create an 'EXTRA_APPS' build flag that allow adding apps that are not in the *.list file
- ...

Note that I put the app under dev_apps/, since some apps lists contain 'apps/*', which would include it automatically if we put it under apps/.

TODO:
- Hide the app from the home screen
